### PR TITLE
Use Python 3 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ julia:
 notifications:
   email: false
 before_install:
-  - (sudo apt-get -qq update && sudo apt-get install -y python python-pip && sudo pip install pandas && sudo pip install matplotlib)
+  - (sudo apt-get -qq update && sudo apt-get install -y python3 python3-pip && sudo pip3 install pandas && sudo pip3 install matplotlib)
 script:
     - julia -e 'using Pkg; Pkg.clone(pwd())'
     - julia -e 'using Pkg; Pkg.build("Pandas")'


### PR DESCRIPTION
As of https://github.com/JuliaPy/PyCall.jl/pull/512 PyCall.jl defaults to `python3`