### PR TITLE
Fix/cleanup CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,13 @@ julia:
   - 1.0
 notifications:
   email: false
+addons:
+  apt:
+    packages:
+      - python3
+      - python3-pip
 before_install:
-  - (sudo apt-get -qq update && sudo apt-get install -y python3 python3-pip && sudo pip3 install pandas)
+  - sudo pip3 install pandas
 script:
     - julia -e 'using Pkg; Pkg.clone(pwd())'
     - julia -e 'using Pkg; Pkg.build("Pandas")'

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ addons:
       - python3
       - python3-pip
 before_install:
+  - sudo pip3 install numpy
+  - sudo pip3 install Cython
   - sudo pip3 install pandas
 script:
     - julia -e 'using Pkg; Pkg.clone(pwd())'

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,3 @@ before_install:
   - sudo pip3 install numpy
   - sudo pip3 install Cython
   - sudo pip3 install pandas
-script:
-    - julia -e 'using Pkg; Pkg.clone(pwd())'
-    - julia -e 'using Pkg; Pkg.build("Pandas")'
-    - julia -e 'using Pkg; Pkg.test("Pandas")'


### PR DESCRIPTION
This is something I had to during the reverse dependency testing #47.  First commit just switches the setup to use the higher-level API.  Second commit fixes the installation problem of pandas.  Third commit removes `script:` so that it uses the default configuration which is pretty robust.