### PR TITLE
Use Ubuntu Xenial and the latest Pip to use wheels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 # Documentation: http://docs.travis-ci.com/user/languages/julia/
 language: julia
-sudo: required
 os:
   - linux
 dist: xenial
@@ -15,6 +14,7 @@ addons:
       - python3
       - python3-pip
 before_install:
-  - sudo pip3 install --upgrade pip
-  - sudo pip3 install pandas
-  - sudo pip3 install tables
+  - pip3 install --user --upgrade pip
+  - pip --version
+  - pip install --user pandas
+  - pip install --user tables

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: julia
 sudo: required
 os:
   - linux
+dist: xenial
 julia:
   - 0.7
   - 1.0
@@ -14,7 +15,6 @@ addons:
       - python3
       - python3-pip
 before_install:
-  - sudo pip3 install numpy
-  - sudo pip3 install Cython
+  - sudo pip3 install --upgrade pip
   - sudo pip3 install pandas
   - sudo pip3 install tables


### PR DESCRIPTION
Travis's default Ubuntu Trusty comes with Python 3.4 which is not
supported by many Python packages any more.  This patch specifies
Ubuntu Xenial which has Python 3.5 so that we can use pre-build binary
from PyPI.