### PR TITLE
A very minor tweak for PackageCompiler

### DIFF
--- a/src/Pandas.jl
+++ b/src/Pandas.jl
@@ -24,6 +24,7 @@ const pandas_raw = PyNULL()
 function __init__()
     copy!(np, pyimport_conda("numpy", "numpy"))
     copy!(pandas_raw, pyimport_conda("pandas", "pandas"))
+    empty!(type_map)  # for behaving nicely in system image
     for (pandas_expr, julia_type) in pre_type_map
         type_map[pandas_expr()] = julia_type
     end


### PR DESCRIPTION
This PR is a very minor tweak for Pandas to behave slightly nicely when it is compiled into a system image.  Without this change, Pandas.jl compiled into system image can have `PyNULL` in `Pandas.type_map`:

```julia
julia> Pandas.type_map
Dict{PyCall.PyObject,Type} with 22 entries:
  PyObject <class 'pandas.core.indexes.base.Index'>               => Index
  PyObject NULL                                                   => Iloc
  PyObject <class 'pandas.core.indexing._IXIndexer'>              => Ix
  PyObject <class 'pandas.core.groupby.groupby.DataFrameGroupBy'> => GroupBy
  PyObject <class 'pandas.core.indexing._iLocIndexer'>            => Iloc
  PyObject NULL                                                   => HDFStore
  PyObject <class 'pandas.core.frame.DataFrame'>                  => DataFrame
  PyObject <class 'pandas.core.indexes.multi.MultiIndex'>         => MultiIndex
  PyObject <class 'pandas.core.window.Rolling'>                   => Rolling
  PyObject NULL                                                   => MultiIndex
  PyObject <class 'pandas.core.groupby.groupby.SeriesGroupBy'>    => SeriesGroupBy
  PyObject <class 'pandas.core.indexing._LocIndexer'>             => Loc
  PyObject NULL                                                   => SeriesGroupBy
  PyObject NULL                                                   => Series
  PyObject NULL                                                   => Ix
  PyObject NULL                                                   => Loc
  PyObject NULL                                                   => GroupBy
  PyObject NULL                                                   => Index
  PyObject <class 'pandas.core.series.Series'>                    => Series
  PyObject NULL                                                   => DataFrame
  PyObject <class 'pandas.io.pytables.HDFStore'>                  => HDFStore
  PyObject NULL                                                   => Rolling
```

while after this PR you have

```julia
julia> Pandas.type_map
Dict{PyCall.PyObject,Type} with 11 entries:
  PyObject <class 'pandas.core.groupby.groupby.SeriesGroupBy'>    => SeriesGroupBy
  PyObject <class 'pandas.core.indexing._IXIndexer'>              => Ix
  PyObject <class 'pandas.io.pytables.HDFStore'>                  => HDFStore
  PyObject <class 'pandas.core.groupby.groupby.DataFrameGroupBy'> => GroupBy
  PyObject <class 'pandas.core.indexing._LocIndexer'>             => Loc
  PyObject <class 'pandas.core.indexing._iLocIndexer'>            => Iloc
  PyObject <class 'pandas.core.series.Series'>                    => Series
  PyObject <class 'pandas.core.window.Rolling'>                   => Rolling
  PyObject <class 'pandas.core.indexes.base.Index'>               => Index
  PyObject <class 'pandas.core.indexes.multi.MultiIndex'>         => MultiIndex
  PyObject <class 'pandas.core.frame.DataFrame'>                  => DataFrame
```

as in normal Pandas.

I'd say this is a super minor issue since:

* `pyisinstance` ignores (returns false) when the type is null
* `pandas_wrap` ignores the entry in `type_map` if it is ignored by `pyisinstance`
* This behavior is observable only if `Pandas.__init__` is called in the `--output-o` mode that generates the system image.

I don't know if this change is appropriate.  It just that seeing uninitialized `PyNULL` does not feel right... :)
