### PR TITLE
Setup GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,71 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+    tags: '*'
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+        architecture: [x64]
+        python-version: ['3']
+        julia-version: ['1.0', '1.5', 'nightly']
+        include:
+          - os: windows-latest
+            architecture: x86
+            python-version: '3'
+            julia-version: '1'
+      fail-fast: false
+    name: Test
+      Julia ${{ matrix.julia-version }}
+      Python ${{ matrix.python-version }}
+      ${{ matrix.os }} ${{ matrix.architecture }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup python
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: ${{ matrix.architecture }}
+      - run: python -m pip install --upgrade pip
+      - run: python -m pip install pandas tables
+
+      - name: Setup julia
+        uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.julia-version }}
+          arch: ${{ matrix.architecture }}
+          show-versioninfo: true
+      - uses: julia-actions/julia-buildpkg@v1
+        env:
+          PYTHON: python
+
+      - uses: actions/cache@v1
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
+
+      - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v1
+        with:
+          file: ./lcov.info
+          flags: unittests
+          name: codecov-umbrella


### PR DESCRIPTION
PyCall just moved its CI to GitHub Actions https://github.com/JuliaPy/PyCall.jl/pull/825 and I've been using a similar setup in PyJulia. I find it much easier to work with when you have to set up two languages. So, how about moving Pandas.jl to GitHub Actions as well?

This PR also introduces CI with Windows and macOS. Currently, it fails with Windows x86.

close #34 (cc @davidanthoff)
