### PR TITLE
add-1.7-to-julia_version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           - windows-latest
         architecture: [x64]
         python-version: ['3']
-        julia-version: ['1.6', 'nightly']
+        julia-version: ['1.6', '1.7', 'nightly']
         include:
           - os: windows-latest
             architecture: x86


### PR DESCRIPTION
It's a good idea to test with 1.7(the current stable version)