### PR TITLE
Fix Tables.jl implementation

### DIFF
--- a/src/tables.jl
+++ b/src/tables.jl
@@ -10,5 +10,4 @@ function _construct_pandas_from_tables(source)
 end
 
 Tables.columnaccess(::DataFrame) = true
-Tables.rowaccess(::DataFrame) = true
 Tables.istable(::DataFrame) = true

--- a/test/test_tables.jl
+++ b/test/test_tables.jl
@@ -20,8 +20,14 @@ df_cols = Tables.columns(df)
 @test Tables.getcolumn(df_cols, :Val) == [7863.0, 7834.0, 7803.0]
 @test Tables.getcolumn(df_cols, :Temp) == [20.0, 100.0, 200.0]
 
-@test Tables.rowaccess(df)
 @test Tables.columnaccess(df)
 @test Tables.istable(df)
+
+@test Tables.columntable(df) ==
+    (Temp=[20.0, 100.0, 200.0], Val=[7863.0, 7834.0, 7803.0], Gr=[1, 1, 1])
+@test Tables.rowtable(df) ==
+    [(Temp=20.0, Val=7863.0, Gr=1)
+     (Temp=100.0, Val=7834.0, Gr=1)
+     (Temp=200.0, Val=7803.0, Gr=1)]
 
 end

--- a/test/test_tables.jl
+++ b/test/test_tables.jl
@@ -24,10 +24,10 @@ df_cols = Tables.columns(df)
 @test Tables.istable(df)
 
 @test Tables.columntable(df) ==
-    (Temp=[20.0, 100.0, 200.0], Val=[7863.0, 7834.0, 7803.0], Gr=[1, 1, 1])
+    (Val=[7863.0, 7834.0, 7803.0], Temp=[20.0, 100.0, 200.0], Gr=[1, 1, 1])
 @test Tables.rowtable(df) ==
-    [(Temp=20.0, Val=7863.0, Gr=1)
-     (Temp=100.0, Val=7834.0, Gr=1)
-     (Temp=200.0, Val=7803.0, Gr=1)]
+    [(Val=7863.0, Temp=20.0, Gr=1)
+     (Val=7834.0, Temp=100.0, Gr=1)
+     (Val=7803.0, Temp=200.0, Gr=1)]
 
 end

--- a/test/test_tables.jl
+++ b/test/test_tables.jl
@@ -23,8 +23,12 @@ df_cols = Tables.columns(df)
 @test Tables.columnaccess(df)
 @test Tables.istable(df)
 
-@test Tables.columntable(df)[[:Val, :Temp, :Gr]] ==
-    Tables.columntable(Tables.rowtable(df))[[:Val, :Temp, :Gr]] ==
-    (Val=[7863.0, 7834.0, 7803.0], Temp=[20.0, 100.0, 200.0], Gr=[1, 1, 1])
+ct = Tables.columntable(df)
+rt = Tables.rowtable(df)
+@test Tables.columntable(rt) == ct
+@test length(ct) == 3
+@test ct.Val == [7863.0, 7834.0, 7803.0]
+@test ct.Temp == [20.0, 100.0, 200.0]
+@test ct.Gr == [1, 1, 1]
 
 end

--- a/test/test_tables.jl
+++ b/test/test_tables.jl
@@ -23,11 +23,8 @@ df_cols = Tables.columns(df)
 @test Tables.columnaccess(df)
 @test Tables.istable(df)
 
-@test Tables.columntable(df) ==
+@test Tables.columntable(df)[[:Val, :Temp, :Gr]] ==
+    Tables.columntable(Tables.rowtable(df))[[:Val, :Temp, :Gr]] ==
     (Val=[7863.0, 7834.0, 7803.0], Temp=[20.0, 100.0, 200.0], Gr=[1, 1, 1])
-@test Tables.rowtable(df) ==
-    [(Val=7863.0, Temp=20.0, Gr=1)
-     (Val=7834.0, Temp=100.0, Gr=1)
-     (Val=7803.0, Temp=200.0, Gr=1)]
 
 end


### PR DESCRIPTION
Defining both row and column access is not needed and it causes problems as defining `Tables.rowaccess` to return `true` requires implementing `Tables.rows`.

Anyway once column access is defined, Tables.jl provides everything automatically to iterate over rows for consumers that need it.

Should fix https://github.com/JuliaPy/Pandas.jl/issues/88.

Cc: @malmaud, @ronisbr, @bkamins