### PR TITLE
Fix `TableTraits` functions failing on non-standard index

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,10 @@ jobs:
       Python ${{ matrix.python-version }}
       ${{ matrix.os }} ${{ matrix.architecture }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           architecture: ${{ matrix.architecture }}
@@ -42,7 +42,7 @@ jobs:
       - run: python -m pip install pandas
 
       - name: Setup julia
-        uses: julia-actions/setup-julia@v1
+        uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.julia-version }}
           arch: ${{ matrix.architecture }}
@@ -51,21 +51,11 @@ jobs:
         env:
           PYTHON: python
 
-      - uses: actions/cache@v1
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
-
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v5
         with:
-          file: ./lcov.info
+          files: ./lcov.info
           flags: unittests
           name: codecov-umbrella

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Pandas"
 uuid = "eadc2687-ae89-51f9-a5d9-86b5a6373a9c"
-version = "1.6.1"
+version = "1.6.2"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/tabletraits.jl
+++ b/src/tabletraits.jl
@@ -7,10 +7,8 @@ IteratorInterfaceExtensions.isiterable(x::DataFrame) = true
 TableTraits.isiterabletable(x::DataFrame) = true
 
 function TableTraits.getiterator(df::DataFrame)
-    col_names_raw = [i for i in Pandas.columns(df)]
-    col_names = Symbol.(col_names_raw)
-
-    column_data = [eltype(df[i])==String ? [df[i][j] for j=1:length(df)] : values(df[i]) for i in col_names_raw]
+    col_names = Symbol.(Pandas.columns(df))
+    column_data = ([df[i]...] for i in col_names)
 
     return create_tableiterator(column_data, col_names)
 end
@@ -19,10 +17,10 @@ TableTraits.supports_get_columns_copy_using_missing(df::DataFrame) = true
 
 function TableTraits.get_columns_copy_using_missing(df::Pandas.DataFrame)
     # return a named tuple of columns here
-    col_names_raw = [i for i in Pandas.columns(df)]
-    col_names = Symbol.(col_names_raw)
-    cols = (Array(eltype(df[i])==String ? [df[i][j] for j=1:length(df)] : df[i]) for i in col_names_raw)
-    return NamedTuple{tuple(col_names...)}(tuple(cols...))
+    col_names = Symbol.(Pandas.columns(df))
+    column_data = Tuple([df[i]...] for i in col_names)
+
+    return NamedTuple(col_names .=> column_data)
 end
 
 function _construct_pandas_from_iterabletable(source)

--- a/test/test_tabletraits.jl
+++ b/test/test_tabletraits.jl
@@ -57,4 +57,11 @@ it3_collected = collect(IteratorInterfaceExtensions.getiterator(df3))
 cols3 = TableTraits.get_columns_copy_using_missing(df3)
 @test isequal(cols3, (a=[NaN,2.], b=["John", "Sally"], c=[3.2, NaN]))
 
+# Create a non-standard index in the python representation
+df4 = DataFrame(["a",]; index=[1,], columns=[:x])
+cols4 = TableTraits.get_columns_copy_using_missing(df4)
+@test length(cols4) == 1
+it4 = IteratorInterfaceExtensions.getiterator(df4)
+@test length(it4) == 1
+
 end


### PR DESCRIPTION
When using an index other than the default `RangeIndex`, the `TableTraits` functions currently fail as they assume a monotonically increasing range beginning from 0.

This PR addresses that issue.

I also cleaned up the code as it was adding an extra special case for `String`s that was not necessary.